### PR TITLE
introduce START TRANSCATION FOR command

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1476,6 +1476,9 @@ typedef void (*drop_database_t)(handlerton *hton, char *path);
 
 typedef int (*panic_t)(handlerton *hton, enum ha_panic_function flag);
 
+typedef int (*start_trans_for_t)(handlerton *hton, THD *thd, uint typ,
+                                 const List<Item> &args);
+
 typedef int (*start_consistent_snapshot_t)(handlerton *hton, THD *thd);
 
 /**
@@ -2644,6 +2647,7 @@ struct handlerton {
   create_t create;
   drop_database_t drop_database;
   panic_t panic;
+  start_trans_for_t start_trans_for;
   start_consistent_snapshot_t start_consistent_snapshot;
   flush_logs_t flush_logs;
   show_status_t show_status;
@@ -7185,6 +7189,7 @@ int ha_resize_key_cache(KEY_CACHE *key_cache);
 int ha_change_key_cache(KEY_CACHE *old_key_cache, KEY_CACHE *new_key_cache);
 
 /* transactions: interface to handlerton functions */
+int ha_start_trans_for(THD *thd, uint typ, const List<Item> &args);
 int ha_start_consistent_snapshot(THD *thd);
 int ha_commit_trans(THD *thd, bool all, bool ignore_global_read_lock = false);
 int ha_commit_attachable(THD *thd);

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -3581,6 +3581,7 @@ LEX::LEX()
       plugins(PSI_NOT_INSTRUMENTED),
       insert_update_values_map(nullptr),
       option_type(OPT_DEFAULT),
+      start_transaction_for(false),
       drop_temporary(false),
       sphead(nullptr),
       // Initialize here to avoid uninitialized variable warnings.

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3933,6 +3933,9 @@ struct LEX : public Query_tables_list {
   */
   bool grant_privilege;
   uint slave_thd_opt, start_transaction_opt;
+  bool start_transaction_for;
+  uint start_transaction_type;
+  List<Item> start_transaction_args;
   int select_number;  ///< Number of query block (by EXPLAIN)
   uint8 create_view_algorithm;
   uint8 create_view_check;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4240,6 +4240,10 @@ int mysql_execute_command(THD *thd, bool first_level) {
       break;
     }
     case SQLCOM_BEGIN:
+      if (lex->start_transaction_for) {
+        if (ha_start_trans_for(thd, lex->start_transaction_type,
+                           lex->start_transaction_args)) goto error;
+      }
       if (trans_begin(thd, lex->start_transaction_opt)) goto error;
       my_ok(thd);
       break;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -2433,6 +2433,7 @@ simple_statement:
         | shutdown_stmt
         | signal_stmt                   { $$= nullptr; }
         | start                         { $$= nullptr; }
+        | start_for                     { $$= nullptr; }
         | start_replica_stmt            { $$= nullptr; }
         | stop_replica_stmt             { $$= nullptr; }
         | truncate_stmt
@@ -9366,6 +9367,35 @@ start_transaction_option:
         | READ_SYM WRITE_SYM
           {
             $$= MYSQL_START_TRANS_OPT_READ_WRITE;
+          }
+        ;
+
+start_for:
+          START_SYM TRANSACTION_SYM NUM FOR_SYM '(' opt_start_transaction_arg_list ')'
+          {
+            Lex->sql_command= SQLCOM_BEGIN;
+            Lex->start_transaction_for= true;
+
+            int error;
+            longlong trx_typ= my_strtoll10($3.str, nullptr, &error);
+            MYSQL_YYABORT_UNLESS(error <= 0);
+            Lex->start_transaction_type= trx_typ;
+          }
+        ;
+
+opt_start_transaction_arg_list:
+          /* empty */ {}
+        | start_transaction_arg_list {}
+        ;
+
+start_transaction_arg_list:
+        literal
+          {
+            Lex->start_transaction_args.push_back($1);
+          }
+        | start_transaction_arg_list ',' literal
+          {
+            Lex->start_transaction_args.push_back($3);
           }
         ;
 

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -265,6 +265,8 @@ bool trans_commit(THD *thd, bool ignore_global_read_lock) {
   thd->variables.option_bits &= ~OPTION_BEGIN;
   thd->get_transaction()->reset_unsafe_rollback_flags(Transaction_ctx::SESSION);
   thd->lex->start_transaction_opt = 0;
+  thd->lex->start_transaction_for = false;
+  thd->lex->start_transaction_args.clear();
 
   /* The transaction should be marked as complete in P_S. */
   assert(thd->m_transaction_psi == nullptr);
@@ -406,6 +408,8 @@ bool trans_rollback(THD *thd) {
   thd->variables.option_bits &= ~OPTION_BEGIN;
   thd->get_transaction()->reset_unsafe_rollback_flags(Transaction_ctx::SESSION);
   thd->lex->start_transaction_opt = 0;
+  thd->lex->start_transaction_for = false;
+  thd->lex->start_transaction_args.clear();
 
   /* The transaction should be marked as complete in P_S. */
   assert(thd->m_transaction_psi == nullptr);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1636,6 +1636,18 @@ static void innodb_pre_dd_shutdown(handlerton *) {
   }
 }
 
+/** Start a parameterized transaction.
+@param[in]      hton            Handle to the handlerton structure
+@param[in]      thd             Thread/connection descriptor
+@param[in]      typ             Type of transaction
+@param[in]      args            Transaction arguments
+@return Operation status */
+static int innobase_start_trx_for(
+    handlerton *hton,
+    THD *thd,
+    uint typ,
+    const List<Item> &args);
+
 /** Creates an InnoDB transaction struct for the thd if it does not yet have
  one. Starts a new InnoDB transaction if a transaction is not yet started. And
  assigns a new snapshot for a consistent read if the transaction does not yet
@@ -5146,6 +5158,7 @@ static int innodb_init(void *p) {
   innobase_hton->panic = innodb_shutdown;
   innobase_hton->partition_flags = innobase_partition_flags;
 
+  innobase_hton->start_trans_for = innobase_start_trx_for;
   innobase_hton->start_consistent_snapshot =
       innobase_start_trx_and_assign_read_view;
 
@@ -5687,6 +5700,23 @@ void innobase_commit_low(trx_t *trx) /*!< in: transaction handle */
     ut_ad(DB_SUCCESS == error);
   }
   trx->will_lock = 0;
+}
+
+/** Registers a parameterized transaction. */
+static int innobase_start_trx_for(
+  handlerton *hton,
+  THD *thd,
+  uint typ,
+  const List<Item> &args)
+{
+  // TODO(jchan): Implement.
+  std::string str;
+  for (auto &arg : args) {
+    str.append(arg.full_name());
+    str.append(",");
+  }
+  std::cout << "txn type: " << typ << ", args: " << str << std::endl;
+  return 0;
 }
 
 /** Creates an InnoDB transaction struct for the thd if it does not yet have


### PR DESCRIPTION
This commit changes the parser to support a new way to start a
transaction---the START TRANSACTION FOR command. The syntax is

```
START TRANSACTION [transaction_type] FOR ([transaction_args])
```

This command is identical to START TRANSACTION (or BEGIN), except it
first registers a parameterized transaction with the underlying
storage engines. The storage engines can use this information to make
scheduling decisions.

The purpose of the transaction type and the transaction args is to
enable us to map a transaction to a scheduling cluster. The type is an
unsigned integer, and the arguments are a list of literals.