### PR TITLE
change start transaction argument type to integer

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2365,7 +2365,7 @@ int ha_release_savepoint(THD *thd, SAVEPOINT *sv) {
 struct start_trans_for_params {
   bool warn;
   uint typ;
-  List<Item> args;
+  std::vector<int> args;
 };
 
 static bool start_trans_for_handlerton(THD *thd, plugin_ref plugin, void *arg) {
@@ -2378,7 +2378,7 @@ static bool start_trans_for_handlerton(THD *thd, plugin_ref plugin, void *arg) {
   return false;
 }
 
-int ha_start_trans_for(THD *thd, uint typ, const List<Item> &args) {
+int ha_start_trans_for(THD *thd, uint typ, const std::vector<int> &args) {
   start_trans_for_params arg;
   arg.warn = true;
   arg.typ = typ;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1477,7 +1477,7 @@ typedef void (*drop_database_t)(handlerton *hton, char *path);
 typedef int (*panic_t)(handlerton *hton, enum ha_panic_function flag);
 
 typedef int (*start_trans_for_t)(handlerton *hton, THD *thd, uint typ,
-                                 const List<Item> &args);
+                                 const std::vector<int> &args);
 
 typedef int (*start_consistent_snapshot_t)(handlerton *hton, THD *thd);
 
@@ -7189,7 +7189,7 @@ int ha_resize_key_cache(KEY_CACHE *key_cache);
 int ha_change_key_cache(KEY_CACHE *old_key_cache, KEY_CACHE *new_key_cache);
 
 /* transactions: interface to handlerton functions */
-int ha_start_trans_for(THD *thd, uint typ, const List<Item> &args);
+int ha_start_trans_for(THD *thd, uint typ, const std::vector<int> &args);
 int ha_start_consistent_snapshot(THD *thd);
 int ha_commit_trans(THD *thd, bool all, bool ignore_global_read_lock = false);
 int ha_commit_attachable(THD *thd);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4241,8 +4241,15 @@ int mysql_execute_command(THD *thd, bool first_level) {
     }
     case SQLCOM_BEGIN:
       if (lex->start_transaction_for) {
+        std::vector<int> args;
+        for (Item &arg: lex->start_transaction_args) {
+          String str;
+          arg.val_str(&str);
+          int a = std::stoi(str.ptr());
+          args.push_back(a);
+        }
         if (ha_start_trans_for(thd, lex->start_transaction_type,
-                           lex->start_transaction_args)) goto error;
+                               args)) goto error;
       }
       if (trans_begin(thd, lex->start_transaction_opt)) goto error;
       my_ok(thd);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1646,7 +1646,7 @@ static int innobase_start_trx_for(
     handlerton *hton,
     THD *thd,
     uint typ,
-    const List<Item> &args);
+    const std::vector<int> &args);
 
 /** Creates an InnoDB transaction struct for the thd if it does not yet have
  one. Starts a new InnoDB transaction if a transaction is not yet started. And
@@ -5707,15 +5707,14 @@ static int innobase_start_trx_for(
   handlerton *hton,
   THD *thd,
   uint typ,
-  const List<Item> &args)
+  const std::vector<int> &args)
 {
   // TODO(jchan): Implement.
-  std::string str;
+  std::cout << "txn type: " << typ << ", args: ";
   for (auto &arg : args) {
-    str.append(arg.full_name());
-    str.append(",");
+    std::cout << arg << ",";
   }
-  std::cout << "txn type: " << typ << ", args: " << str << std::endl;
+  std::cout << std::endl;
   return 0;
 }
 


### PR DESCRIPTION
Previously, the type was `List<Item>`, but since we're assuming hot keys are known a priori, we can map hot keys to an integer and pass the arguments as a `std::vector<int>`.